### PR TITLE
fix: keep telemetry running without SD card

### DIFF
--- a/device/firmware/main/main.h
+++ b/device/firmware/main/main.h
@@ -1,6 +1,8 @@
 #ifndef MAIN_H
 #define MAIN_H
 
+#include <stdbool.h>
+
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "mqtt_client.h"
@@ -242,14 +244,14 @@ static inline void log_prepare(uint8_t type, log_t *log) {
 }
 
 static inline int LOG(uint8_t type, log_t *log) {
-  if (logqueue == NULL) return 0;
   log_prepare(type, log);
+  if (logqueue == NULL) return 0;
   return xQueueSend(logqueue, log, 0);
 }
 
 static inline int LOG_FROM_ISR(uint8_t type, log_t *log) {
-  if (logqueue == NULL) return 0;
   log_prepare(type, log);
+  if (logqueue == NULL) return 0;
   return xQueueSendFromISR(logqueue, log, NULL);
 }
 

--- a/device/firmware/main/main.h
+++ b/device/firmware/main/main.h
@@ -20,6 +20,8 @@ extern QueueHandle_t cantxqueue;
 extern esp_mqtt_client_handle_t mqtt;
 extern volatile bool file_op_busy;
 
+bool sdcard_log_writer_active(void);
+
 /***** nvs storage *****/
 typedef struct {
   struct {

--- a/device/firmware/main/main.h
+++ b/device/firmware/main/main.h
@@ -256,11 +256,12 @@ static inline int LOG_FROM_ISR(uint8_t type, log_t *log) {
 }
 
 static inline void SYSLOG(const char *msg) {
-  if (logqueue == NULL || syslogqueue == NULL) return;
-  log_t log;
+  if (logqueue == NULL && syslogqueue == NULL) return;
+  log_t log = { 0 };
   strncpy(log.payload.system_event.msg, msg, sizeof(log.payload.system_event.msg));  // no need to null-terminate
-  LOG(LOG_TYPE_SYSTEM, &log);
-  xQueueSend(syslogqueue, &log, 0);
+  log_prepare(LOG_TYPE_SYSTEM, &log);
+  if (logqueue != NULL) xQueueSend(logqueue, &log, 0);
+  if (syslogqueue != NULL) xQueueSend(syslogqueue, &log, 0);
 }
 
 static inline void ERROR_LOG(state_t *state, state_component_t component, const char *msg) {

--- a/device/firmware/main/network/mqtt.c
+++ b/device/firmware/main/network/mqtt.c
@@ -34,7 +34,7 @@ static void free_queue(void) {
 }
 
 static void restore_queue(void) {
-  if (IS_OK(&logbuf.run, SD) && logqueue == NULL) {
+  if (sdcard_log_writer_active() && logqueue == NULL) {
     logqueue = xQueueCreate(2560, sizeof(log_t));
   }
 
@@ -404,7 +404,11 @@ static void mqtt_handle_data(esp_mqtt_event_handle_t evt) {
       }
 
       memcpy(message.data, evt->data, message.data_length_code);
-      if (!file_op_busy) xQueueSend(cantxqueue, &message, 0);
+
+      if (!file_op_busy) {
+        QueueHandle_t q = cantxqueue;
+        if (q != NULL) xQueueSend(q, &message, 0);
+      }
     }
 
     else if (STREQL(dir[2], "ls")) {  // list files

--- a/device/firmware/main/network/mqtt.c
+++ b/device/firmware/main/network/mqtt.c
@@ -34,10 +34,21 @@ static void free_queue(void) {
 }
 
 static void restore_queue(void) {
-  logqueue    = xQueueCreate(2560, sizeof(log_t));
-  syslogqueue = xQueueCreate(32, sizeof(log_t));
-  canlogqueue = xQueueCreate(1024, sizeof(log_t));
-  cantxqueue  = xQueueCreate(4, sizeof(twai_message_t));
+  if (IS_OK(&logbuf.run, SD) && logqueue == NULL) {
+    logqueue = xQueueCreate(2560, sizeof(log_t));
+  }
+
+  if (syslogqueue == NULL) {
+    syslogqueue = xQueueCreate(32, sizeof(log_t));
+  }
+
+  if (canlogqueue == NULL) {
+    canlogqueue = xQueueCreate(1024, sizeof(log_t));
+  }
+
+  if (cantxqueue == NULL) {
+    cantxqueue = xQueueCreate(4, sizeof(twai_message_t));
+  }
 }
 
 static void task_file_upload(void *arg) {

--- a/device/firmware/main/peripheral/sdcard.c
+++ b/device/firmware/main/peripheral/sdcard.c
@@ -11,6 +11,11 @@
 extern struct timeval boot;
 
 char logpath[64];
+static TaskHandle_t sdcard_task_handle = NULL;
+
+bool sdcard_log_writer_active(void) {
+  return sdcard_task_handle != NULL;
+}
 
 static bool telemetry_queue_init(void) {
   if (syslogqueue == NULL) {
@@ -59,8 +64,18 @@ static void task_sdcard(void *pvParameters) {
       continue;
     }
 
+    QueueHandle_t q = logqueue;
+
+    if (q == NULL) {
+      if (!IS_FATAL(&logbuf.run, SD)) {
+        FATAL_LOG(&logbuf.run, SD, "log queue unavailable");
+      }
+      xTaskDelayUntil(&xLastWakeTime, pdMS_TO_TICKS(200));
+      continue;
+    }
+
     do {
-      if ((ret = xQueueReceive(logqueue, &log, 0)) == pdTRUE) {
+      if ((ret = xQueueReceive(q, &log, 0)) == pdTRUE) {
         write(fd, &log, sizeof(log));
         write_count++;
       }
@@ -144,7 +159,9 @@ void sdcard_init(void) {
     goto finish;
   }
 
-  if (xTaskCreate(task_sdcard, "sdcard", 4096, (void *)fd, 7, NULL) != pdPASS) {
+  TaskHandle_t task = NULL;
+
+  if (xTaskCreate(task_sdcard, "sdcard", 4096, (void *)fd, 7, &task) != pdPASS) {
     FATAL_LOG(&init, SD, "task create failure");
     close(fd);
     QueueHandle_t q = logqueue;
@@ -152,6 +169,8 @@ void sdcard_init(void) {
     if (q) vQueueDelete(q);
     goto finish;
   }
+
+  sdcard_task_handle = task;
 
   INFO(SD, "log file: %s", logpath);
 

--- a/device/firmware/main/peripheral/sdcard.c
+++ b/device/firmware/main/peripheral/sdcard.c
@@ -12,6 +12,26 @@ extern struct timeval boot;
 
 char logpath[64];
 
+static bool queue_init(void) {
+  if (logqueue == NULL) {
+    logqueue = xQueueCreate(2560, sizeof(log_t));
+  }
+
+  if (syslogqueue == NULL) {
+    syslogqueue = xQueueCreate(32, sizeof(log_t));
+  }
+
+  if (canlogqueue == NULL) {
+    canlogqueue = xQueueCreate(1024, sizeof(log_t));
+  }
+
+  if (cantxqueue == NULL) {
+    cantxqueue = xQueueCreate(4, sizeof(twai_message_t));
+  }
+
+  return logqueue != NULL && syslogqueue != NULL && canlogqueue != NULL && cantxqueue != NULL;
+}
+
 /*******************************************************************************
  * save log queue to SD card every 1000 ms
  ******************************************************************************/
@@ -61,6 +81,11 @@ static void task_sdcard(void *pvParameters) {
  * init SDIO, mount filesystem and create task
  ******************************************************************************/
 void sdcard_init(void) {
+  if (queue_init() != true) {
+    FATAL_LOG(&init, SD, "queue create failure");
+    goto finish;
+  }
+
   esp_vfs_fat_sdmmc_mount_config_t mount_config = {
     .format_if_mount_failed   = false,
     .max_files                = 4,
@@ -106,16 +131,12 @@ void sdcard_init(void) {
 
   if (fd < 0) {
     FATAL_LOG(&init, SD, "file open failure");
+    goto finish;
   }
-
-  // create log queue and sdcard task
-  logqueue    = xQueueCreate(2560, sizeof(log_t));
-  syslogqueue = xQueueCreate(32, sizeof(log_t));
-  canlogqueue = xQueueCreate(1024, sizeof(log_t));
-  cantxqueue  = xQueueCreate(4, sizeof(twai_message_t));
 
   if (xTaskCreate(task_sdcard, "sdcard", 4096, (void *)fd, 7, NULL) != pdPASS) {
     FATAL_LOG(&init, SD, "task create failure");
+    close(fd);
     goto finish;
   }
 

--- a/device/firmware/main/peripheral/sdcard.c
+++ b/device/firmware/main/peripheral/sdcard.c
@@ -12,11 +12,7 @@ extern struct timeval boot;
 
 char logpath[64];
 
-static bool queue_init(void) {
-  if (logqueue == NULL) {
-    logqueue = xQueueCreate(2560, sizeof(log_t));
-  }
-
+static bool telemetry_queue_init(void) {
   if (syslogqueue == NULL) {
     syslogqueue = xQueueCreate(32, sizeof(log_t));
   }
@@ -29,7 +25,15 @@ static bool queue_init(void) {
     cantxqueue = xQueueCreate(4, sizeof(twai_message_t));
   }
 
-  return logqueue != NULL && syslogqueue != NULL && canlogqueue != NULL && cantxqueue != NULL;
+  return syslogqueue != NULL && canlogqueue != NULL && cantxqueue != NULL;
+}
+
+static bool log_queue_init(void) {
+  if (logqueue == NULL) {
+    logqueue = xQueueCreate(2560, sizeof(log_t));
+  }
+
+  return logqueue != NULL;
 }
 
 /*******************************************************************************
@@ -81,7 +85,7 @@ static void task_sdcard(void *pvParameters) {
  * init SDIO, mount filesystem and create task
  ******************************************************************************/
 void sdcard_init(void) {
-  if (queue_init() != true) {
+  if (telemetry_queue_init() != true) {
     FATAL_LOG(&init, SD, "queue create failure");
     goto finish;
   }
@@ -134,9 +138,18 @@ void sdcard_init(void) {
     goto finish;
   }
 
+  if (log_queue_init() != true) {
+    FATAL_LOG(&init, SD, "log queue create failure");
+    close(fd);
+    goto finish;
+  }
+
   if (xTaskCreate(task_sdcard, "sdcard", 4096, (void *)fd, 7, NULL) != pdPASS) {
     FATAL_LOG(&init, SD, "task create failure");
     close(fd);
+    QueueHandle_t q = logqueue;
+    logqueue        = NULL;
+    if (q) vQueueDelete(q);
     goto finish;
   }
 


### PR DESCRIPTION
## Summary

- Create live telemetry queues before attempting to mount the SD card.
- Keep MQTT CAN/syslog/command telemetry available when SD mount or log file setup fails.
- Create the SD-backed log queue only after the log file is open and the SD writer task can drain it.
- Prepare log headers and checksums before checking the SD log queue so live telemetry snapshots remain parseable without SD logging.

## Root Cause

SD initialization created the shared log, syslog, CAN telemetry, and CAN TX queues only after a successful SD mount and log file open. When the SD card was missing or failed to mount, CAN frames could still be received by the firmware, but the live MQTT telemetry path had no CAN queue to publish from. Snapshot records such as gyro data could also be copied without a prepared log header/checksum, causing the web parser to reject them.

The first fix moved queue creation before SD mount, but creating the SD log queue without an SD writer task left a large file-log queue with no consumer. This update separates live telemetry queues from the SD-backed log queue: syslog, CAN telemetry, and CAN TX queues are available without SD, while `logqueue` exists only when SD file logging is actually running.

## Impact

The device can now report `SD = FATAL` while continuing to publish live telemetry. SD-backed file logging and file download/list operations still require a working SD card. When SD is unavailable, the firmware avoids allocating and filling the unused SD log queue.